### PR TITLE
simplify registration/revocation with just 1 muxrpc

### DIFF
--- a/docs/Alias/Registration.md
+++ b/docs/Alias/Registration.md
@@ -5,32 +5,20 @@ An [internal user](../Stakeholders/Internal%20user.md) who does not have an alia
 ### Specification
 
 1. An internal user with SSB ID `feedId` and a room server with SSB ID `roomId` are connected to each other via secret-handshake
-1. The internal user [signs into](../Setup/Sign-in%20with%20SSB.md) the room's [web dashboard](../Setup/Web%20Dashboard.md)
-1. The internal user uses the dashboard's "Register Alias" feature, inputting the string `alias` as candidate [alias string](Alias%20string.md)
-1. The room checks whether that `alias` is valid (see spec in [Alias string](Alias%20string.md))
-    1. If it is invalid, respond with an error on the web dashboard
+1. The internal user chooses a `alias` as a candidate [alias string](Alias%20string.md)
+1. The internal user calls a specific [muxrpc](https://github.com/ssb-js/muxrpc/) `async` API `registerAlias(alias, feedId, signature, callback)` where `signature` is a cryptographic signature of the string `=alias-registration:${roomId}:${feedId}:${alias}` using `feedId`'s cryptographic keypair, read more about it in the [alias database](Alias%20database.md) spec
+1. The room, upon receiving the `registerAlias` muxrpc call, checks whether that `alias` is valid (see spec in [Alias string](Alias%20string.md))
+    1. If it is invalid, respond `registerAlias` with an error
     1. Else, proceed (below)
 1. The room checks whether there already exists an entry in the [Alias database](Alias%20database.md) associated with this `feedId`
-    1. If there is, respond with an error on the web dashboard
+    1. If there is, respond `registerAlias` with an error
     1. Else, proceed (below)
 1. The room checks whether there already exists an entry in the [Alias database](Alias%20database.md) with the *key* `alias`
-    1. If there is, respond with an error on the web dashboard
-    1. Else, proceed (below)
-1. The room receives the internal user's `alias` via HTTPS, and calls a specific [muxrpc](https://github.com/ssb-js/muxrpc/) `async` API `confirmAlias(alias, callback)` at the internal user
-1. The internal user receives the muxrpc message, and prompts the user interface to confirm this choice
-    1. If it is denied, reply to the room with an error
-        1. The room then responds with an error on the web dashboard
-    1. Else, proceed (below)
-1. The internal user responds to the room's `confirmAlias` muxrpc call with a cryptographic signature of the string `=alias-registration:${roomId}:${feedId}:${alias}` using `feedId`'s cryptographic keypair, referred to as `sig`, read more about it in the [alias database](Alias%20database.md) spec
-1. The room receives the `confirmAlias` response, and checks whether the `alias` is still unclaimed in the [Alias database](Alias%20database.md) and there is no other alias associated with this `feedId`
-    1. If there exists, then
-        1. Calls a muxrpc `async` API `aliasRegistered(alias, error, callback)` at the internal user
-        1. Respond with an error on the web dashboard
+    1. If there is, respond `registerAlias` with an error
     1. Else, proceed (below)
 1. The room adds an entry to its [Alias database](Alias%20database.md) for `key=alias` & `value=feedId+sig`
-1. The room calls a muxrpc `async` API `aliasRegistered(alias, true, callback)` at the internal user
-1. The room responds back to the web dashboard client with "success"
-1. The internal user receives the `aliasRegistered` muxrpc call from the room and checks the second argument:
+1. The room responds `registerAlias` with `true`, indicating success
+1. The internal user receives the room's response to `registerAlias`
     1. If it is an error, then (optionally) display a user interface failure to register the alias
     1. If it is `true`, then publish an SSB msg of type `about` with a field listing all its aliases for various rooms, where this specific `alias` is included. The specific schema of the message type is an application-level concern
 
@@ -38,33 +26,19 @@ The above algorithm is also provided below as a UML sequence diagram:
 
 ```mermaid
 sequenceDiagram
-  participant Umux as SSB peer
-  participant Uweb as Browser client
+  participant U as SSB peer
   participant R as Room server
 
-  Note over Umux,R: Sign-in with SSB
-
-  Uweb->>R: "Register alias" feature in the dashboard<br/>with string `alias` as input
+  U->>R: (muxrpc async) `registerAlias(alias, feedId, signature)`
   alt `alias` is an invalid alias string<br/>or already taken in the alias database<br/>or `feedId` already has an alias
-    R-->>Uweb: error
-  else else
-    R->>Umux: (muxrpc async) `confirmAlias(alias)`
-    Umux->>Umux: Prompts the user<br/>interface to<br/>confirm the choice
-    alt user denies it
-        Umux-->>R: respond confirmAlias with an error
-        R-->>Uweb: error
-    else user accepts it
-        Umux-->>R: respond confirmAlias with a cryptographic signature
-        alt `alias` no longer valid
-            R->>Umux: (muxrpc async) `aliasRegistered(alias, error)`
-            R-->>Uweb: error
-        else `alias` is still valid
-            R->>R: Adds an entry to<br/>its alias database
-            R->>Umux: (muxrpc async) `aliasRegistered(alias, true)`
-            R-->>Uweb: HTTP 200
-            Umux->>Umux: Publishes an SSB<br/>msg of type<br/>`about`
-        end
+    R-->>U: Respond registerAlias with an error
+    opt
+        U->>U: Display user interface error
     end
+  else else
+    R->>R: Adds an entry to<br/>its alias database
+    R-->>U: Respond registerAlias with `true`
+    U->>U: Publishes an SSB<br/>msg of type<br/>`about`
   end
 ```
 

--- a/docs/Alias/Revocation.md
+++ b/docs/Alias/Revocation.md
@@ -4,26 +4,15 @@ When an [internal user](../Stakeholders/Internal%20user.md) who has [registered]
 
 ### Specification
 
-1. An internal user with SSB ID `feedId` and a room server with SSB ID `roomId` are connected to each other via secret-handshake. We assume the internal user has [registered](Registration.md) `alias` in the past
-1. The internal user [signs into](../Setup/Sign-in%20with%20SSB.md) the room's [web dashboard](../Setup/Web%20Dashboard.md)
-1. The internal user uses the dashboard's "Revoke Alias" feature
-1. The room checks whether there exists an entry in the [Alias database](Alias%20database.md) associated with `feedId`
-    1. If there is no entry, respond with an error on the web dashboard
+1. An internal user with SSB ID `feedId` and a room server with SSB ID `roomId` are connected to each other via secret-handshake
+1. The internal user calls a specific [muxrpc](https://github.com/ssb-js/muxrpc/) `async` API `registerAlias(null, feedId, null, callback)`
+1. The room, upon receiving the `registerAlias` muxrpc call, checks whether there exists an entry in the [Alias database](Alias%20database.md) associated with `feedId`
+    1. If there is no entry, respond `registerAlias` with an error
     1. Else, proceed (below)
-1. The room calls a specific [muxrpc](https://github.com/ssb-js/muxrpc/) `async` API `confirmAlias(null, callback)` at the internal user
-1. The internal user receives the muxrpc message, and prompts the user interface to confirm the choice of revoking the alias
-    1. If it is denied, reply to the room with an error
-        1. The room then responds with an error on the web dashboard
-    1. Else, proceed (below)
-1. The internal user responds to the room's muxrpc call with a `true` boolean
-1. The room receives the `confirmAlias` response, and attempts to remove the entry in the [Alias database](Alias%20database.md) associated with `feedId`
-    1. If the database entry removal failed for any reason
-        1. Call a muxrpc `async` API `aliasRegistered(null, error, callback)` at the internal user
-        1. Respond with an error on the web dashboard
-    1. Else, proceed (below)
-1. The room calls a muxrpc `async` API `aliasRegistered(null, true, callback)` at the internal user
-1. The room responds back to the web dashboard client with "success"
-1. The internal user receives the `aliasRegistered` muxrpc call from the room and checks the second argument:
+1. The room adds an entry to its [Alias database](Alias%20database.md) for `key=alias` & `value=feedId+sig`
+1. The room removes the entry from the [Alias database](Alias%20database.md) associated with `feedId`
+1. The room responds `registerAlias` with `true`, indicating success
+1. The internal user receives the room's response to `registerAlias`
     1. If it is an error, then (optionally) display a user interface failure to revoke the alias
     1. If it is `true`, then publish an SSB msg of type `about` with a field listing all its aliases for various rooms, where this specific `alias` is no longer listed. The specific schema of the message type is an application-level concern
 
@@ -31,36 +20,21 @@ The above algorithm is also provided below as a UML sequence diagram:
 
 ```mermaid
 sequenceDiagram
-  participant Umux as SSB peer
-  participant Uweb as Browser client
+  participant U as SSB peer
   participant R as Room server
 
-  Note over Umux,R: Sign-in with SSB
-
-  Uweb->>R: "Revoke alias" feature in the dashboard<br/>
+  U->>R: (muxrpc async) `registerAlias(null, feedId, null)`
   alt no alias exists in the alias database for `feedId`
-    R-->>Uweb: error
-  else else
-    R->>Umux: (muxrpc async) `confirmAlias(null)`
-    Umux->>Umux: Prompts the user<br/>interface to<br/>confirm the choice
-    alt user denies it
-        Umux-->>R: respond confirmAlias with an error
-        R-->>Uweb: error
-    else user accepts it
-        Umux-->>R: respond confirmAlias with `true`
-        R->>R: Attempts to remove<br/>the entry in the<br/>alias database
-        alt removal failed
-            R->>Umux: (muxrpc async) `aliasRegistered(null, error)`
-            R-->>Uweb: error
-        else removal succeeded
-            R->>Umux: (muxrpc async) `aliasRegistered(null, true)`
-            R-->>Uweb: HTTP 200
-            Umux->>Umux: Publishes an SSB<br/>msg of type<br/>`about`
-        end
+    R-->>U: Respond registerAlias with an error
+    opt
+        U->>U: Display user interface error
     end
+  else else
+    R->>R: Remove the entry in<br/>the alias database
+    R-->>U: Respond registerAlias with `true`
+    U->>U: Publishes an SSB<br/>msg of type<br/>`about`
   end
 ```
-
 
 ### Security considerations
 

--- a/docs/Appendix/muxrpc.md
+++ b/docs/Appendix/muxrpc.md
@@ -1,6 +1,5 @@
 ## List of new muxrpc APIs
 
 - async
-  - `confirmAlias(alias, callback)`
-  - `aliasRegistered(alias, answer, callback)`
+  - `registerAlias(alias, feedId, signature, callback)`
   - `signIn(cc, sr, sc, callback)`


### PR DESCRIPTION
## Summary

cc @arj03 @cryptix 

Registration/revocation protocol was getting quite complicated, with 3 parties (client's SSB peer, client on the browser, and room server) doing all sorts of calls back and forth. Also, three muxrpc APIs were needed: `signIn`, `confirmAlias`, `aliasRegistered`.

I basically dropped the idea of registering the alias on the web UI. Instead, it's just one muxrpc call, `registerAlias`.

**Why did I use the web UI registration idea in the first place?** To give some context, see issue #2. Originally I wanted to have **only one** new muxrpc added, `signIn`, but it turned that for registration it was important to cryptographically sign the alias, and the browser user can't do that, so then I started adding new muxrpc APIs. Now, the compromise is that only two APIs were added for this spec: `signIn` and `registerAlias`. It's not 1 API, which was my original goal, but it's much better than 3 APIs and a convoluted protocol. Also, in total, this should be easier for different SSB apps to implement.

**What's the use of the web UI?** It will be basically be used for any action that doesn't need cryptographic signatures, i.e. changes that are considered "preferences in the room", mostly moderation: banning some IDs, deleting aliases (when they use "evil" names), creating invites, changing overall settings.

## Before

![Screenshot from 2021-01-12 16-31-16](https://user-images.githubusercontent.com/90512/104329352-7ca76d00-54f5-11eb-8027-898a7d459f64.png)

## After

![Screenshot from 2021-01-12 16-30-56](https://user-images.githubusercontent.com/90512/104329376-8204b780-54f5-11eb-8529-508eca871855.png)
