### PR TITLE
spec server-initiated sign-in with ssb

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,3 +28,4 @@
   - [Alias database](docs/Alias/Alias%20database.md)
 - [Appendix](docs/Appendix/Readme.md)
   - [List of new muxrpc APIs](docs/Appendix/muxrpc.md)
+  - [List of new SSB URIs](docs/Appendix/ssb-uris.md)

--- a/docs/Alias/Web endpoint.md
+++ b/docs/Alias/Web endpoint.md
@@ -72,7 +72,7 @@ As an additional endpoint for programmatic purposes, the HTTP endpoint `https://
 Suppose the alias is `alice`, registered for the user ID `@FlieaFef19uJ6jhHwv2CSkFrDLYKJd/SuIS71A5Y2as=.ed25519` at the room with host name `scuttlebutt.eu`. Then the alias endpoint `https://alice.scuttlebutt.eu` responds with the following SSB URI (without spaces nor newlines):
 
 ```
-ssb:address/net_shs/scuttlebutt.eu/8008/51w4nYL0k7mRzDG
+ssb:address/netshs/scuttlebutt.eu/8008/51w4nYL0k7mRzDG
 w20KQqCjt35y8qLiBNtWk3MX7ppo%3D?roomId=ed25519%2F51w4nY
 L0k7mRzDGw20KQqCjt35y8qLiBNtWk3MX7ppo%3D&userId=ed25519
 %2FFlieaFef19uJ6jhHwv2CSkFrDLYKJd_SuIS71A5Y2as%3D&alias
@@ -81,7 +81,7 @@ lrzvmxTNt3d0MNTf%2BSLMIxgxf00S5fKAlG2%2FC5NTE0Zq1Mmg%3D
 %3D
 ```
 
-Note the multiserver address for the room is written in an SSB URI friendly format, `ssb:address/net_shs/${host}/${port}/${pubkey}`, that can be converted to canonical multiserver format `net:${host}:${port}~shs:${pubkey}`.
+Note the multiserver address for the room is written in an SSB URI friendly format, `ssb:address/netshs/${host}/${port}/${pubkey}`, that can be converted to canonical multiserver format `net:${host}:${port}~shs:${pubkey}`.
 
 The JSON endpoint `https://alice.scuttlebutt.eu/json` would respond with the following JSON:
 

--- a/docs/Appendix/muxrpc.md
+++ b/docs/Appendix/muxrpc.md
@@ -2,5 +2,5 @@
 
 - async
   - `room.registerAlias(alias, feedId, signature, callback)`
-  - `httpAuth.signIn(cc, sc, sr, callback)`
-  - `httpAuth.signOut(authToken, callback)`
+  - `httpAuth.signIn(sc, cc, cr, callback)`
+  - `httpAuth.signOut(sc, callback)`

--- a/docs/Appendix/ssb-uris.md
+++ b/docs/Appendix/ssb-uris.md
@@ -1,0 +1,6 @@
+## List of new SSB URIs
+
+- `ssb:address/${multiserverAddress}`
+  - Special case: `ssb:address/${roomMsAddr}?inviteType=room&inviteCode=${inviteCode}`
+  - Special case: `ssb:address/${roomMsAddr}?roomId=${roomId}&userId=${userId}&alias=${alias}&signature=${signature}`
+- `ssb:httpauth/start/${sid}/${sc}`

--- a/docs/Participation/Invite endpoint.md
+++ b/docs/Participation/Invite endpoint.md
@@ -5,7 +5,7 @@ When [joining](Joining.md) a *Community* room or *Restricted* room, [internal us
 ### Example
 
 1. Invite link is `https://scuttlebutt.eu/join?invite=39c0ac1850ec9af14f1bb73`
-1. User opens that link in a browser, which redirects to `ssb:address/net_shs/scuttlebutt.eu/8008/51w4nYL0k7mRzDG
+1. User opens that link in a browser, which redirects to `ssb:address/netshs/scuttlebutt.eu/8008/51w4nYL0k7mRzDG
 w20KQqCjt35y8qLiBNtWk3MX7ppo%3D?inviteType=room&inviteCode=39c0ac1850ec9af14f1bb73`
 1. User's operating system opens that SSB URI in an SSB app, which then communicates with the room server via muxrpc, read more in [Joining](Joining.md)
 

--- a/docs/Setup/Sign-in with SSB.md
+++ b/docs/Setup/Sign-in with SSB.md
@@ -4,9 +4,9 @@ To access the [WWW dashboard interface](Web%20Dashboard.md), [internal users](..
 
 ### Specification
 
-An [internal user](../Stakeholders/Internal%20user.md) known by its SSB ID `userId` is connected to the room via secret-handshake and muxrpc. A browser client is supposedly the same person or agent as the internal user and wishes to gain access to the web dashboard. All HTTP requests SHOULD be done with HTTPS.
+An [internal user](../Stakeholders/Internal%20user.md) known by its SSB ID `cid` is connected to the room via secret-handshake and muxrpc. A browser client is supposedly the same person or agent as the internal user and wishes to gain access to the web dashboard. All HTTP requests SHOULD be done with HTTPS.
 
-The three sides (browser client, SSB peer, and room server) perform the following [challenge-response authentication](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication) protocol, specified as a following UML sequence diagram. We use the shorthands `cc`, `sr`, `sc`, and `cr` to mean:
+The three sides (browser client, SSB peer, and room server) perform the following [challenge-response authentication](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication) protocol, specified as a UML sequence diagram. We use the shorthands `cc`, `sr`, `sc`, and `cr` to mean:
 
 - `cc`: "client's challenge"
 - `sr`: "server's response"
@@ -22,7 +22,13 @@ The challenges, `cc` and `sc`, are 256-bit [cryptographic nonces](https://en.wik
 - `sr` is the server's cryptographic signature of the string `=http-auth-sign-in:${cid}:${sid}:${cc}:${sc}` where `${x}` means string interpolation of the value `x`
 - `cr` is the client's cryptographic signature of the string `=http-auth-sign-in:${cid}:${sid}:${cc}:${sc}` where `${x}` means string interpolation of the value `x`
 
-The UML sequence diagram for the whole protocol is shown below:
+Both sides generate the nonces, but there are use cases where one side should start first. In other words, the challenge-response protocol described here can be either **client-initiated** or **server-initiated**.
+
+#### Client-initiated protocol
+
+In the client-initiated variant of the challenge-response protocol, the first step is the client creating `cc` and opening a web page in the browser. Then, the server attending to that HTTP request will call `httpAuth.signIn(cc, sc, sr)` on the client SSB peer.
+
+The UML sequence diagram for the whole client-initial protocol is shown below:
 
 ```mermaid
 sequenceDiagram
@@ -30,26 +36,123 @@ sequenceDiagram
   participant Uweb as Browser client
   participant R as Room server
 
-  Umux->>Umux: Generates<br/>challenge `cc`
-  Umux->>Uweb: `https://${roomHost}/login<br/>?userId=${userId}&challenge=${cc}`
-  Uweb->>R: `https://${roomHost}/login<br/>?userId=${userId}&challenge=${cc}`
-  R->>R: Generates<br/>challenge `sc`
-  R->>R: Generates<br/>signature `sr`
+  note over Umux: Generates<br/>challenge `cc`
+  Umux->>Uweb: `https://${roomHost}/login<br/>?userId=${cid}&challenge=${cc}`
+  Uweb->>+R: `https://${roomHost}/login<br/>?userId=${cid}&challenge=${cc}`
+  Note over R: Generates<br/>challenge `sc`
+  Note over R: Generates<br/>signature `sr`
   alt SSB peer is disconnected from the room
     R-->>Uweb: HTTP 403
   else SSB peer is connected to the room
-    R->>Umux: (muxrpc async) `httpAuth.signIn(cc, sc, sr)`
+    R->>+Umux: (muxrpc async) `httpAuth.signIn(cc, sc, sr)`
     alt `sr` is incorrect
       Umux-->>R: respond httpAuth.signIn with error "`sr` is incorrect"
       R-->>Uweb: HTTP 403
     else `sr` is correct
-      Umux->>Umux: Generates<br/>signature `cr`
-      Umux-->>R: respond httpAuth.signIn with `cr`
+      Note over Umux: Generates<br/>signature `cr`
+      Umux-->>-R: respond httpAuth.signIn with `cr`
       alt `cr` is incorrect
         R-->>Uweb: HTTP 403
       else `cr` is correct
-        R-->>Uweb: HTTP 200, auth token
-        Uweb->>Uweb: Stores auth token as a cookie
+        R-->>-Uweb: HTTP 200, auth token
+        Note over Uweb: Stores auth token as a cookie
+      end
+    end
+  end
+```
+
+```mermaid
+sequenceDiagram
+  participant Umux as SSB peer
+  participant Uweb as Browser client
+  participant R as Room server
+
+  rect rgb(230, 255, 230)
+    note over Umux: Generates<br/>challenge `cc`
+    Umux->>Uweb: `https://${roomHost}/login<br/>?userId=${cid}&challenge=${cc}`
+    Uweb->>+R: `https://${roomHost}/login<br/>?userId=${cid}&challenge=${cc}`
+    Note over R: Generates<br/>challenge `sc`
+    R->>+Umux: (muxrpc async) `httpAuth.signIn(sc, cc, null)`
+    Note over Umux: Generates<br/>signature `cr`
+    Umux-->>-R: respond httpAuth.signIn with `cr`
+    R-->>-Uweb: HTTP 200, auth token
+    Note over Uweb: Stores auth token as a cookie
+  end
+```
+
+#### Server-initiated protocol
+
+In the server-initiated variant of the challenge-response protocol, the first step is the browser requesting the server to login with a certain `cid` (or `alias`, which the server knows how to map to a `cid`). The server answers the browser, which in turn displays an SSB URI which the SSB peer knows how to open.
+
+The primary difference between this variant and the previous one is the muxrpc async RPC `httpAuth.requestSignIn` which is used for the SSB peer to inform the room peer about the `cc`. Afterwards, the protocol is similar to the server-initiated one, with the minor addition of Server-Sent Events between the browser and the room.
+
+The UML sequence diagram for the whole server-initial protocol is shown below:
+
+```mermaid
+sequenceDiagram
+  participant Umux as SSB peer
+  participant Uweb as Browser client
+  participant R as Room server
+
+  rect rgb(230, 255, 230)
+    Uweb->>R: `https://${roomHost}/login?userId=${cid}` or<br/>`https://${roomHost}/login?alias=${alias}`
+    activate R
+    Note over R: Generates<br/>challenge `sc`
+    R-->>Uweb: Displays `ssb:httpauth/start/${sid}/${sc}`
+    Uweb->>R: Subscribe to `/sse/login/${sc}`
+    Uweb->>Umux: Consumes SSB URI
+    Note over Umux: Generates<br/>challenge `cc`
+    Note over Umux: Generates<br/>signature `cr`
+    Umux->>+R: (muxrpc async) `httpAuth.signIn(sc, cc, cr)`
+    R-->>-Umux: `true`
+    R-->>Uweb: (SSE) "redirect to ${url}"
+    Uweb->>+R: GET `${url}`
+    R-->>-Uweb: HTTP 200, auth token
+    deactivate R
+    Note over Uweb: Stores auth token as a cookie
+  end
+```
+
+```mermaid
+sequenceDiagram
+  participant Umux as SSB peer
+  participant Uweb as Browser client
+  participant R as Room server
+
+  Uweb->>R: `https://${roomHost}/login?userId=${cid}` or<br/>`https://${roomHost}/login?alias=${alias}`
+  activate R
+  Note over R: Generates<br/>challenge `sc`
+  R-->>Uweb: Displays `ssb:httpauth/start/${sid}/${sc}`
+  Uweb->>R: Subscribe to `/sse/login/${sc}`
+  Uweb->>Umux: Consumes SSB URI
+  Note over Umux: Generates<br/>challenge `cc`
+  Umux->>+R: (muxrpc async) `httpAuth.startSignIn(cc, sc)`
+  Note over R: Generates<br/>signature `sr`
+  R-->>-Umux: `true`
+  alt Timeout, or SSB peer is disconnected from the room, or other errors
+    R-->>Uweb: (SSE) "redirect to ${url}"
+    Uweb->>+R: GET `${url}`
+    R-->>-Uweb: HTTP 403
+  else SSB peer is connected to the room
+    R->>Umux: (muxrpc async) `httpAuth.signIn(cc, sc, sr)`
+    alt `sr` is incorrect
+      Umux-->>R: respond httpAuth.signIn with error "`sr` is incorrect"
+      R-->>Uweb: (SSE) "redirect to ${url}"
+      Uweb->>+R: GET `${url}`
+      R-->>-Uweb: HTTP 403
+    else `sr` is correct
+      Note over Umux: Generates<br/>signature `cr`
+      Umux-->>R: respond httpAuth.signIn with `cr`
+      alt `cr` is incorrect
+        R-->>Uweb: (SSE) "redirect to ${url}"
+        Uweb->>+R: GET `${url}`
+        R-->>-Uweb: HTTP 403
+      else `cr` is correct
+        R-->>Uweb: (SSE) "redirect to ${url}"
+        Uweb->>+R: GET `${url}`
+        R-->>-Uweb: HTTP 200, auth token
+        deactivate R
+        Note over Uweb: Stores auth token as a cookie
       end
     end
   end
@@ -65,12 +168,12 @@ sequenceDiagram
   participant Uweb as Browser client
   participant R as Room server
 
-  Umux->>R: (muxrpc async) `httpAuth.signOut(authtoken)`
-  R->>R: Invalidates `authtoken`
-  R-->>Umux: respond httpAuth.signOut with `true`
+  Umux->>+R: (muxrpc async) `httpAuth.signOut(sc)`
+  Note over R: Invalidates `authtoken`<br/>associated with `sc`
+  R-->>-Umux: respond httpAuth.signOut with `true`
   Note over Uweb,R: Potentially thereafter...
-  Uweb->>R: Authenticate using `authtoken`
-  R-->>Uweb: HTTP 401
+  Uweb->>+R: Authenticate using `authtoken`
+  R-->>-Uweb: HTTP 401
 ```
 
 The browser client also has the option of signing out with HTTP endpoints. This does not require a muxrpc call with the SSB peer. See UML sequence diagram:
@@ -80,10 +183,10 @@ sequenceDiagram
   participant Uweb as Browser client
   participant R as Room server
 
-  Uweb->>R: `/logout`
-  R->>R: Invalidates `authtoken`
-  R-->>Uweb: HTTP 200
+  Uweb->>+R: `/logout`
+  Note over R: Invalidates `authtoken`
+  R-->>-Uweb: HTTP 200
   Note over Uweb,R: Potentially thereafter...
-  Uweb->>R: Authenticate using `authtoken`
-  R-->>Uweb: HTTP 401
+  Uweb->>+R: Authenticate using `authtoken`
+  R-->>-Uweb: HTTP 401
 ```


### PR DESCRIPTION
@keks @cryptix Would appreciate your feedback! :pray: 

-----

**Context:** I met cryptix and we figured that *Sign-in with SSB* has a missing feature.

**Problem:** The spec was assuming that the dance is initiated by the client SSB peer which generates a challenge *and then* opens a page in the browser, but there are often cases where you'd like to *begin with the browser*, such as inputting your SSB ID or alias. The spec didn't account for that and assumed that we always had to begin it in the client SSB peer.

**Other problem as I digged deeper:** if we want both sides (server and client) to verify each other's solutions, we need to send messages 3 times (A-->B generates challenge, B-->A sends solution, A-->B sends solution), and this can't be done with 1 muxrpc calls, it needs 2 muxrpc calls, and that sounds too much. I started questioning whether we need to do ["mutual authentication"](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication) given that **secret-handshake assures us that both sides are mutually authenticated**.

**Solution:** I slimmed down the sign-in protocol a bit, so that there is only `cc` (client nonce), `sc` (server nonce), `cr` (client solution). This means that we would only need 1 muxrpc call. The idea is that `cc` and `sc` act like session IDs, and all that needs to be done is the client "acknowledge" these by creating a signature `cr` that certifies those session IDs. We don't need to authenticate the peers themselves, we just need the client to certify those nonces.

See these UML diagrams (that omit the error handling cases, just to make it smaller and easier to grok the dance):

**Client-initiated sign-in protocol**

![Screenshot from 2021-02-10 17-01-27](https://user-images.githubusercontent.com/90512/107527624-a8377900-6bc1-11eb-8f7f-e7cf4d86f5fb.png)

**Server-initiated sign-in protocol**

![Screenshot from 2021-02-10 17-01-57](https://user-images.githubusercontent.com/90512/107527663-b4bbd180-6bc1-11eb-9f20-f1112b2974c2.png)


**PDF:** [rev2021-02-10.pdf](https://github.com/ssb-ngi-pointer/rooms2/files/5958959/rev2021-02-10.pdf)
