### PR TITLE
output html, rewrite relative links & mermaid docs

### DIFF
--- a/docs/Alias/Alias database.md
+++ b/docs/Alias/Alias database.md
@@ -6,12 +6,30 @@ This is a database that stores all aliases that were [registered](Registration.m
 
 The following is a mock up of a key-value store:
 
-| Key | Value |
-|----|-----|
-| `alice` | `@FlieaFef19uJ6jhHwv2CSkFrDLYKJd/SuIS71A5Y2as=.ed25519` plus signature |
-| `bob` | `@25WfId3Vx/gyMAZqCyZzhtW4iPtUVXB/aOMYbq44P4c=.ed25519` plus signature |
-| `carla` | `@dRE+jzKo0VWX6JbcSVATyOvFlbjCNwPWNzQLkTGenac=.ed25519` plus signature |
-| `daniel` | `@SMMgb4bZAgRgtAPdMw4loQeZL9lQgsRDi+xin0ZDzAg=.ed25519` plus signature |
+<table>
+<tr>
+<th>Key</th>
+<th>Value</th>
+</tr>
+<tbody>
+<tr>
+<td><code>alice</code></td>
+<td><code>@FlieaFef19uJ6jhHwv2CSkFrDLYKJd/SuIS71A5Y2as=.ed25519</code> plus signature</td>
+</tr>
+<tr>
+<td><code>bob</code></td>
+<td><code>@25WfId3Vx/gyMAZqCyZzhtW4iPtUVXB/aOMYbq44P4c=.ed25519</code> plus signature</td>
+</tr>
+<tr>
+<td><code>carla</code></td>
+<td><code>@dRE+jzKo0VWX6JbcSVATyOvFlbjCNwPWNzQLkTGenac=.ed25519</code> plus signature</td>
+</tr>
+<tr>
+<td><code>daniel</code></td>
+<td><code>@SMMgb4bZAgRgtAPdMw4loQeZL9lQgsRDi+xin0ZDzAg=.ed25519</code> plus signature</td>
+</tr>
+</tbody>
+</table>
 
 ### Specification
 

--- a/tools/package.json
+++ b/tools/package.json
@@ -7,6 +7,8 @@
     "remark": "13.0.0",
     "remark-behead": "2.3.3",
     "remark-heading-gap": "^4.0.0",
+    "remark-html": "^13.0.1",
+    "remark-mermaid": "^0.2.0",
     "remark-slug": "^6.0.0",
     "remark-toc": "^7.0.0",
     "to-vfile": "6.1.0",

--- a/tools/wrap.js
+++ b/tools/wrap.js
@@ -1,0 +1,29 @@
+const header = `<html>
+<head>
+<style>
+html {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+table {
+  border-collapse: collapse;
+}
+td, th {
+  padding: 0.5rem;
+  border: 1px #aaa solid;
+}
+</style>
+</head>
+<script crossorigin src="https://unpkg.com/mermaid@8.9.1/dist/mermaid.min.js"></script>
+<body>
+`
+
+const footer = `
+</body>
+</html>
+`
+module.exports = function (input) {
+    return [header, input, footer].join("\n")
+}
+


### PR DESCRIPTION
this patch fixes #14 by outputting an html file and rewriting its links.
mermaid blocks are also rewritten by remark-mermaid for rendering in the
browser. the generated html is wrapped to include an inline-stylesheet
and mermaidjs as a script include.

i also rewrote the markdown table to an html table. the markdown table was breaking in the html output, and as markdown supports html that fixes the issue. also i kinda think html tables are more legible & easier to edit than markdown tables