### PR TITLE
Annotate external links, dotted border for internal

### DIFF
--- a/tools/wrap.js
+++ b/tools/wrap.js
@@ -13,6 +13,13 @@ td, th {
   padding: 0.5rem;
   border: 1px #aaa solid;
 }
+a[href^="http"]::after {
+  content: "⧉";
+}
+a[href^="#"] {
+  text-decoration: none;
+  border-bottom: 1px blue dotted;
+}
 </style>
 </head>
 <script crossorigin src="https://unpkg.com/mermaid@8.9.1/dist/mermaid.min.js"></script>


### PR DESCRIPTION
I was reading on the go yesterday, and was becoming really hesitant to click links because I couldn't discern which were internal / external. This PR fixes that for the HTML export, see below.

![image](https://user-images.githubusercontent.com/3862362/109944922-080fd400-7cd7-11eb-9cd8-48e02220e51c.png)
