### PR TITLE
simplify muxrpcs for register/revoke aliases

### DIFF
--- a/docs/Alias/Registration.md
+++ b/docs/Alias/Registration.md
@@ -27,7 +27,7 @@ sequenceDiagram
   participant R as Room server
 
   U->>R: (muxrpc async) `room.registerAlias(alias, signature)`
-  alt `alias` is an invalid alias string<br/>or already taken in the alias database<br/>or `feedId` already has an alias
+  alt `alias` is an invalid alias string<br/>or already taken in the alias database<br/>or other errors
     R-->>U: Respond room.registerAlias with an error
     opt
         U->>U: Display user interface error

--- a/docs/Alias/Registration.md
+++ b/docs/Alias/Registration.md
@@ -6,12 +6,9 @@ An [internal user](../Stakeholders/Internal%20user.md) who does not have an alia
 
 1. An internal user with SSB ID `feedId` and a room server with SSB ID `roomId` are connected to each other via secret-handshake
 1. The internal user chooses a `alias` as a candidate [alias string](Alias%20string.md)
-1. The internal user calls a specific [muxrpc](https://github.com/ssb-js/muxrpc/) `async` API `room.registerAlias(alias, feedId, signature, callback)` where `signature` is a cryptographic signature of the string `=room-alias-registration:${roomId}:${feedId}:${alias}` using `feedId`'s cryptographic keypair, read more about it in the [alias database](Alias%20database.md) spec
+1. The internal user calls a specific [muxrpc](https://github.com/ssb-js/muxrpc/) `async` API `room.registerAlias(alias, signature, callback)` where `signature` is a cryptographic signature of the string `=room-alias-registration:${roomId}:${feedId}:${alias}` using `feedId`'s cryptographic keypair, read more about it in the [alias database](Alias%20database.md) spec
 1. The room, upon receiving the `room.registerAlias` muxrpc call, checks whether that `alias` is valid (see spec in [Alias string](Alias%20string.md))
     1. If it is invalid, respond `room.registerAlias` with an error
-    1. Else, proceed (below)
-1. The room checks whether there already exists an entry in the [Alias database](Alias%20database.md) associated with this `feedId`
-    1. If there is, respond `room.registerAlias` with an error
     1. Else, proceed (below)
 1. The room checks whether there already exists an entry in the [Alias database](Alias%20database.md) with the *key* `alias`
     1. If there is, respond `room.registerAlias` with an error
@@ -29,7 +26,7 @@ sequenceDiagram
   participant U as SSB peer
   participant R as Room server
 
-  U->>R: (muxrpc async) `room.registerAlias(alias, feedId, signature)`
+  U->>R: (muxrpc async) `room.registerAlias(alias, signature)`
   alt `alias` is an invalid alias string<br/>or already taken in the alias database<br/>or `feedId` already has an alias
     R-->>U: Respond room.registerAlias with an error
     opt
@@ -46,7 +43,7 @@ sequenceDiagram
 
 #### Malicious [internal user](../Stakeholders/Internal%20user.md)
 
-The reason why there can be only one alias for SSB ID is to prevent a malicious internal user from exhausting many or all possible aliases in case the room accidentally allows such malicious user to become an internal user. Arguably, some room implementations could choose to relax this choice, perhaps to allow different aliases for an internal user, that covers typographic mistakes such as `aliec`, `alicce`. For the time being, it seems sensible that each internal user can receive only one alias.
+A malicious internal user could take many or all possible aliases in case the room accidentally allows such malicious user to become an internal user. Arguably, some room implementations could choose to allow only one alias per internal user, and that would still be compliant with this spec.
 
 ### Malicious [room admin](../Stakeholders/Room%20admin.md)
 

--- a/docs/Alias/Revocation.md
+++ b/docs/Alias/Revocation.md
@@ -5,14 +5,14 @@ When an [internal user](../Stakeholders/Internal%20user.md) who has [registered]
 ### Specification
 
 1. An internal user with SSB ID `feedId` and a room server with SSB ID `roomId` are connected to each other via secret-handshake
-1. The internal user calls a specific [muxrpc](https://github.com/ssb-js/muxrpc/) `async` API `room.registerAlias(null, feedId, null, callback)`
-1. The room, upon receiving the `room.registerAlias` muxrpc call, checks whether there exists an entry in the [Alias database](Alias%20database.md) associated with `feedId`
-    1. If there is no entry, respond `room.registerAlias` with an error
+1. The internal user calls a specific [muxrpc](https://github.com/ssb-js/muxrpc/) `async` API `room.revokeAlias(alias, callback)`
+1. The room, upon receiving the `room.revokeAlias` muxrpc call, checks whether there exists an entry in the [Alias database](Alias%20database.md) for `alias`
+    1. If there is no entry, respond `room.revokeAlias` with an error
+    1. Else, if there exists an entry for `alias` but it is not owned by `feedId`, respond `room.revokeAlias` with an error
     1. Else, proceed (below)
-1. The room adds an entry to its [Alias database](Alias%20database.md) for `key=alias` & `value=feedId+sig`
 1. The room removes the entry from the [Alias database](Alias%20database.md) associated with `feedId`
-1. The room responds `room.registerAlias` with `true`, indicating success
-1. The internal user receives the room's response to `room.registerAlias`
+1. The room responds `room.revokeAlias` with `true`, indicating success
+1. The internal user receives the room's response to `room.revokeAlias`
     1. If it is an error, then (optionally) display a user interface failure to revoke the alias
     1. If it is `true`, then publish an SSB msg of type `about` with a field listing all its aliases for various rooms, where this specific `alias` is no longer listed. The specific schema of the message type is an application-level concern
 
@@ -23,15 +23,15 @@ sequenceDiagram
   participant U as SSB peer
   participant R as Room server
 
-  U->>R: (muxrpc async) `room.registerAlias(null, feedId, null)`
-  alt no alias exists in the alias database for `feedId`
-    R-->>U: Respond room.registerAlias with an error
+  U->>R: (muxrpc async) `room.revokeAlias(alias)`
+  alt `alias` does not exist, or other errors
+    R-->>U: Respond room.revokeAlias with an error
     opt
         U->>U: Display user interface error
     end
   else else
     R->>R: Remove the entry in<br/>the alias database
-    R-->>U: Respond room.registerAlias with `true`
+    R-->>U: Respond room.revokeAlias with `true`
     U->>U: Publishes an SSB<br/>msg of type<br/>`about`
   end
 ```

--- a/docs/Appendix/muxrpc.md
+++ b/docs/Appendix/muxrpc.md
@@ -1,6 +1,7 @@
 ## List of new muxrpc APIs
 
 - async
-  - `room.registerAlias(alias, feedId, signature, callback)`
-  - `httpAuth.signIn(sc, cc, cr, callback)`
-  - `httpAuth.signOut(sc, callback)`
+  - `room.registerAlias(alias, signature)`
+  - `room.revokeAlias(alias)`
+  - `httpAuth.signIn(sc, cc, cr)`
+  - `httpAuth.signOut(sc)`


### PR DESCRIPTION
## Summary:

### Registration: 

```diff
-registerAlias(alias, feedId, signature)
+registerAlias(alias, signature)
```

AND

Relaxed requirement that there can only be one alias per member. The **spec** allows multiple aliases per member, although a room **implementation** can choose to restrict to max 1 per member.

### Revocation: 

```diff
-registerAlias(null, feedId, null)
+revokeAlias(alias)
```