### PR TITLE
Review signin and modes

### DIFF
--- a/docs/Setup/Privacy modes.md
+++ b/docs/Setup/Privacy modes.md
@@ -8,6 +8,6 @@ There are three strategies recommended as policies to [join](../Participation/Jo
 
 - **Open**: invite codes are openly known, similar to [ssb-room v1](https://github.com/staltz/ssb-room)
 - **Community**: only [internal users](../Stakeholders/Internal%20user.md) can invite [external users](../Stakeholders/External%20user.md) to become an internal users
-- **Restricted**: only [moderators](../Stakeholders/Moderator.md) can invite [external users](../Stakeholders/External%20user.md) to become an internal users, and [aliases](../Alias/Readme.md) are not supported
+- **Restricted**: only [admins](../Stakeholders/Room%20admin.md) and [moderators](../Stakeholders/Moderator.md) can invite [external users](../Stakeholders/External%20user.md) to become an internal users, and [aliases](../Alias/Readme.md) are not supported
 
 **Joining:** To become a member of the room, peers need to [join the room](../Participation/Joining.md).

--- a/docs/Setup/Sign-in with SSB.md
+++ b/docs/Setup/Sign-in with SSB.md
@@ -41,7 +41,7 @@ sequenceDiagram
   alt SSB peer is disconnected from the room
     R-->>Uweb: HTTP 403
   else SSB peer is connected to the room
-    R->>+Umux: (muxrpc async) `httpAuth.signIn(sc, cc)`
+     R->>+Umux: (muxrpc async) `httpAuth.signIn(sc, cc, null)`
     Note over Umux: Generates<br/>signature `cr`
     Umux-->>-R: respond httpAuth.signIn with `cr`
     alt `cr` is incorrect

--- a/docs/Setup/Sign-in with SSB.md
+++ b/docs/Setup/Sign-in with SSB.md
@@ -4,7 +4,7 @@ To access the [WWW dashboard interface](Web%20Dashboard.md), [internal users](..
 
 ### Specification
 
-An [internal user](../Stakeholders/Internal%20user.md) known by its SSB ID `cid` is connected to the room via secret-handshake and muxrpc. A browser client is supposedly the same person or agent as the internal user and wishes to gain access to the web dashboard. All HTTP requests SHOULD be done with HTTPS.
+An [internal user](../Stakeholders/Internal%20user.md) known by its SSB ID `cid` is connected to the room via secret-handshake and muxrpc. A browser client is supposedly the same person or agent as the internal user and wishes to gain access to the web dashboard. All HTTP requests MUST be done with HTTPS.
 
 The three sides (browser client, SSB peer, and room server) perform the following [challenge-response authentication](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication) protocol, specified as a UML sequence diagram. We use the shorthands `cc`, `sr`, `sc`, and `cr` to mean:
 
@@ -18,7 +18,7 @@ The challenges, `cc` and `sc`, are 256-bit [cryptographic nonces](https://en.wik
 - `cid` is the client's identity from their cryptographic keypair
 - `sid` is the servers's identity from their cryptographic keypair
 - `cc` is a 256-bit nonce created by the client, encoded in base64
-- `sc` is a 256-bit nonce created by the client, encoded in base64
+- `sc` is a 256-bit nonce created by the server, encoded in base64
 - `sr` is the server's cryptographic signature of the string `=http-auth-sign-in:${cid}:${sid}:${cc}:${sc}` where `${x}` means string interpolation of the value `x`
 - `cr` is the client's cryptographic signature of the string `=http-auth-sign-in:${cid}:${sid}:${cc}:${sc}` where `${x}` means string interpolation of the value `x`
 
@@ -57,9 +57,9 @@ sequenceDiagram
 
 #### Server-initiated protocol
 
-In the server-initiated variant of the challenge-response protocol, the first step is the browser requesting the server to login with a certain `cid` (or `alias`, which the server knows how to map to a `cid`). The server answers the browser, which in turn displays an SSB URI which the SSB peer knows how to open.
+In the server-initiated variant of the challenge-response protocol, the first step is the browser requesting a login from the server using a certain `cid` (or `alias`, which the server knows how to map to a `cid`). The server answers the browser, which in turn displays an SSB URI which the SSB peer knows how to open.
 
-The primary difference between this variant and the previous one is the muxrpc async RPC `httpAuth.requestSignIn` which is used for the SSB peer to inform the room peer about the `cc`. Afterwards, the protocol is similar to the server-initiated one, with the minor addition of Server-Sent Events between the browser and the room.
+The primary difference between this variant and the previous one is the muxrpc async RPC `httpAuth.signIn` which is used for the SSB peer to inform the room peer about the `cc`. Afterwards, the protocol is similar to the server-initiated one, with the minor addition of Server-Sent Events between the browser and the room.
 
 The UML sequence diagram for the whole server-initial protocol is shown below:
 

--- a/docs/Setup/Sign-in with SSB.md
+++ b/docs/Setup/Sign-in with SSB.md
@@ -9,24 +9,22 @@ An [internal user](../Stakeholders/Internal%20user.md) known by its SSB ID `cid`
 The three sides (browser client, SSB peer, and room server) perform the following [challenge-response authentication](https://en.wikipedia.org/wiki/Challenge%E2%80%93response_authentication) protocol, specified as a UML sequence diagram. We use the shorthands `cc`, `sr`, `sc`, and `cr` to mean:
 
 - `cc`: "client's challenge"
-- `sr`: "server's response"
 - `sc`: "server's challenge"
 - `cr`: "client's response"
 
-The challenges, `cc` and `sc`, are 256-bit [cryptographic nonces](https://en.wikipedia.org/wiki/Cryptographic_nonce) encoded in base64. The responses, `sr` and `cr`, are cryptographic signatures using the cryptographic keypairs that identify the server and the client, respectively, described below:
+The challenges, `cc` and `sc`, are 256-bit [cryptographic nonces](https://en.wikipedia.org/wiki/Cryptographic_nonce) encoded in base64. The response `cr` is a cryptographic signature using the cryptographic keypair that identifies the client, described below:
 
 - `cid` is the client's identity from their cryptographic keypair
 - `sid` is the servers's identity from their cryptographic keypair
 - `cc` is a 256-bit nonce created by the client, encoded in base64
 - `sc` is a 256-bit nonce created by the server, encoded in base64
-- `sr` is the server's cryptographic signature of the string `=http-auth-sign-in:${cid}:${sid}:${cc}:${sc}` where `${x}` means string interpolation of the value `x`
 - `cr` is the client's cryptographic signature of the string `=http-auth-sign-in:${cid}:${sid}:${cc}:${sc}` where `${x}` means string interpolation of the value `x`
 
 Both sides generate the nonces, but there are use cases where one side should start first. In other words, the challenge-response protocol described here can be either **client-initiated** or **server-initiated**.
 
 #### Client-initiated protocol
 
-In the client-initiated variant of the challenge-response protocol, the first step is the client creating `cc` and opening a web page in the browser. Then, the server attending to that HTTP request will call `httpAuth.signIn(cc, sc, sr)` on the client SSB peer.
+In the client-initiated variant of the challenge-response protocol, the first step is the client creating `cc` and opening a web page in the browser. Then, the server attending to that HTTP request will call `httpAuth.signIn(cc, sc)` on the client SSB peer.
 
 The UML sequence diagram for the whole client-initial protocol is shown below:
 
@@ -43,7 +41,7 @@ sequenceDiagram
   alt SSB peer is disconnected from the room
     R-->>Uweb: HTTP 403
   else SSB peer is connected to the room
-    R->>+Umux: (muxrpc async) `httpAuth.signIn(sc, cc, null)`
+    R->>+Umux: (muxrpc async) `httpAuth.signIn(sc, cc)`
     Note over Umux: Generates<br/>signature `cr`
     Umux-->>-R: respond httpAuth.signIn with `cr`
     alt `cr` is incorrect


### PR DESCRIPTION
* [x] clarify who can create invites in restricted mode
* [x] remove server response (SR) from sign-in with ssb
* [x] harmonize muxrpc call name for sign-in with ssb
* [x] clarify that the login-dance has to happen over HTTPS (not doing so is not an option)
* [x] some small formulation nitpicks

