### PR TITLE
Change muxrpc structure of Sign-in with SSB

### DIFF
--- a/docs/Appendix/muxrpc.md
+++ b/docs/Appendix/muxrpc.md
@@ -3,5 +3,6 @@
 - async
   - `room.registerAlias(alias, signature)`
   - `room.revokeAlias(alias)`
-  - `httpAuth.signIn(sc, cc, cr)`
-  - `httpAuth.signOut()`
+  - `httpAuth.requestSolution(sc, cc)`
+  - `httpAuth.sendSolution(sc, cc, cr)`
+  - `httpAuth.invalidateAllSolutions()`


### PR DESCRIPTION
Summary:

- The order of arguments is always server 1st, client 2nd
- `httpAuth.requestSolution(sc, cc)`
- `httpAuth.sendSolution(sc, cc, cr)`
- `httpAuth.invalidateAllSolutions()`
- `=http-auth-sign-in:${sid}:${cid}:${sc}:${cc}`

@cryptix Could I get your review and approval?