### PR TITLE
Correct the event type for the initial state event

### DIFF
--- a/docs/Participation/Attendants.md
+++ b/docs/Participation/Attendants.md
@@ -27,7 +27,7 @@ When the user subscribes to the `room.attendants` stream, the first event **MUST
     "type": {
       "title": "Event type",
       "type": "string",
-      "pattern": "^(successful)$"
+      "pattern": "^(state)$"
     },
     "ids": {
       "title": "SSB IDs of attendants",


### PR DESCRIPTION
Reference implementation:

https://github.com/ssbc/go-ssb-room/blob/761a3b7244213eae80593d437b44cc00761a6084/muxrpc/test/go/attendants_test.go#L56